### PR TITLE
Added hasOwnProperty checks to array_intersect_key

### DIFF
--- a/functions/array/array_intersect_key.js
+++ b/functions/array/array_intersect_key.js
@@ -17,9 +17,15 @@ function array_intersect_key(arr1) {
     k = '';
 
   arr1keys: for (k1 in arr1) {
+    if (!arr1.hasOwnProperty(k1)) {
+      continue;
+    }
     arrs: for (i = 1; i < argl; i++) {
       arr = arguments[i];
       for (k in arr) {
+        if (!arr.hasOwnProperty(k)) {
+          continue;
+        }
         if (k === k1) {
           if (i === arglm1) {
             retArr[k1] = arr1[k1];


### PR DESCRIPTION
I think that the function should not iterate over properties of the objects' prototypes. Such behavior will probably be unexpected and undesired