### PR TITLE
Fix octal IP errors

### DIFF
--- a/functions/network/ip2long.js
+++ b/functions/network/ip2long.js
@@ -1,40 +1,59 @@
-function ip2long(IP) {
-  //  discuss at: http://phpjs.org/functions/ip2long/
-  // original by: Waldo Malqui Silva (http://waldo.malqui.info)
-  // improved by: Victor
-  //  revised by: fearphage (http://http/my.opera.com/fearphage/)
-  //  revised by: Theriault
-  //   example 1: ip2long('192.0.34.166');
-  //   returns 1: 3221234342
-  //   example 2: ip2long('0.0xABCDEF');
-  //   returns 2: 11259375
-  //   example 3: ip2long('255.255.255.256');
-  //   returns 3: false
+/**
+ * A JavaScript equivalent of PHP's ip2long(). Convert IPv4 address in dotted
+ * notation to 32-bit long integer.
+ * You can pass IP in all possible representations, i.e.:
+ *     192.0.34.166
+ *     0xC0.0x00.0x02.0xEB
+ *     0xC00002EB
+ *     3221226219
+ *     0.0xABCDEF
+ *     255.255.255.256
+ *     0300.0000.0002.0353
+ *     030000001353
+ *
+ * @param string ip IPv4-address in one of possible representations.
+ * @return Number The 32-bit number notation of IP-address expressed in decimal.
+ */
+function ip2long(ip) {
+    // discuss at: http://phpjs.org/functions/ip2long/
+    // original by: Waldo Malqui Silva
+    // improved by: Victor
+    // improved by: Alexander Zubakov
+    //  revised by: fearphage (http://http/my.opera.com/fearphage/)
+    //  revised by: Theriault
 
-  var i = 0;
-  // PHP allows decimal, octal, and hexadecimal IP components.
-  // PHP allows between 1 (e.g. 127) to 4 (e.g 127.0.0.1) components.
-  IP = IP.match(
-    /^([1-9]\d*|0[0-7]*|0x[\da-f]+)(?:\.([1-9]\d*|0[0-7]*|0x[\da-f]+))?(?:\.([1-9]\d*|0[0-7]*|0x[\da-f]+))?(?:\.([1-9]\d*|0[0-7]*|0x[\da-f]+))?$/i
-  ); // Verify IP format.
-  if (!IP) {
-    // Invalid format.
-    return false;
-  }
-  // Reuse IP variable for component counter.
-  IP[0] = 0;
-  for (i = 1; i < 5; i += 1) {
-    IP[0] += !!((IP[i] || '')
-      .length);
-    IP[i] = parseInt(IP[i]) || 0;
-  }
-  // Continue to use IP for overflow values.
-  // PHP does not allow any component to overflow.
-  IP.push(256, 256, 256, 256);
-  // Recalculate overflow of last component supplied to make up for missing components.
-  IP[4 + IP[0]] *= Math.pow(256, 4 - IP[0]);
-  if (IP[1] >= IP[5] || IP[2] >= IP[6] || IP[3] >= IP[7] || IP[4] >= IP[8]) {
-    return false;
-  }
-  return IP[1] * (IP[0] === 1 || 16777216) + IP[2] * (IP[0] <= 2 || 65536) + IP[3] * (IP[0] <= 3 || 256) + IP[4] * 1;
+    // PHP allows decimal, octal, and hexadecimal IP components.
+    // PHP allows between 1 (e.g. 127) to 4 (e.g 127.0.0.1) components.
+    ip = ip.match(
+        /^([1-9]\d*|0[0-7]*|0x[\da-f]+)(?:\.([1-9]\d*|0[0-7]*|0x[\da-f]+))?(?:\.([1-9]\d*|0[0-7]*|0x[\da-f]+))?(?:\.([1-9]\d*|0[0-7]*|0x[\da-f]+))?$/i
+    );
+
+    // invalid format.
+    if (ip === null) return false;
+
+    // reuse IP variable for component counter.
+    ip[0] = 0;
+    for (var i = 1; i <= 4; i++) {
+        // calculate radix for parseInt()
+        var radix = 10;
+
+        // radix should be 8 or 16
+        if (typeof ip[i] !== 'undefined' && ip[i].length > 1 && ip[i][0] === '0')
+            radix = ip[i][1].toLowerCase() === 'x' ? 16 : 8;
+
+        ip[0] += !! ((ip[i] || '').length);
+        ip[i] = parseInt(ip[i], radix) || 0;
+    }
+
+    // continue to use IP for overflow values.
+    // PHP does not allow any component to overflow.
+    ip.push(256, 256, 256, 256);
+
+    // recalculate overflow of last component supplied to make up for missing components.
+    ip[4 + ip[0]] *= Math.pow(256, 4 - ip[0]);
+
+    if (ip[1] >= ip[5] || ip[2] >= ip[6] || ip[3] >= ip[7] || ip[4] >= ip[8])
+        return false;
+
+    return ip[1] * (ip[0] === 1 || 16777216) + ip[2] * (ip[0] <= 2 || 65536) + ip[3] * (ip[0] <= 3 || 256) + ip[4] * 1;
 }

--- a/functions/network/ip2long.js
+++ b/functions/network/ip2long.js
@@ -1,26 +1,20 @@
-/**
- * A JavaScript equivalent of PHP's ip2long(). Convert IPv4 address in dotted
- * notation to 32-bit long integer.
- * You can pass IP in all possible representations, i.e.:
- *     192.0.34.166
- *     0xC0.0x00.0x02.0xEB
- *     0xC00002EB
- *     3221226219
- *     0.0xABCDEF
- *     255.255.255.256
- *     0300.0000.0002.0353
- *     030000001353
- *
- * @param string ip IPv4-address in one of possible representations.
- * @return Number The 32-bit number notation of IP-address expressed in decimal.
- */
 function ip2long(ip) {
-    // discuss at: http://phpjs.org/functions/ip2long/
-    // original by: Waldo Malqui Silva
-    // improved by: Victor
-    // improved by: Alexander Zubakov
-    //  revised by: fearphage (http://http/my.opera.com/fearphage/)
-    //  revised by: Theriault
+  //  discuss at: http://phpjs.org/functions/ip2long/
+  // original by: Waldo Malqui Silva (http://waldo.malqui.info)
+  // improved by: Victor
+  // improved by: Alexander Zubakov (http://xinit.co/)
+  //  revised by: fearphage (http://http/my.opera.com/fearphage/)
+  //  revised by: Theriault
+  //   example 1: ip2long('192.0.34.166');
+  //   returns 1: 3221234342
+  //   example 2: ip2long('0.0xABCDEF');
+  //   returns 2: 11259375
+  //   example 3: ip2long('255.255.255.256');
+  //   returns 3: false
+  //   example 4: ip2long('0300.0000.0002.0353');
+  //   returns 4: 3221226219
+  //   example 5: ip2long('030000001353');
+  //   returns 5: 3221226219
 
     // PHP allows decimal, octal, and hexadecimal IP components.
     // PHP allows between 1 (e.g. 127) to 4 (e.g 127.0.0.1) components.


### PR DESCRIPTION
Previous version of function could not correctly convert IPv4 which contain octal parts, i.e. '0300.0000.0002.0353' or '030000001353'. The problem is in parseInt() function which can't correctly define radix (the base in mathematical numeral systems) for octal values and always use 10 in numbers started from '0'.

Docs says that different implementations (of JavaScript engine) produce different results when a radix is not specified, so I enhanced function to explicitly use radix as the second parameter of parseInt().

References:
1. parseInt() docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt