### PR TITLE
Fixed 'array' orthography

### DIFF
--- a/experimental/array/array_column.js
+++ b/experimental/array/array_column.js
@@ -16,7 +16,7 @@ function array_column(array, column_key, index_key) {
   for (var i = 0; i < len; i++) {
     if (!typeof array[i] === "object") {
       continue;
-    } else if (index_key === null && arrya[i].hasOwnProperty(column_key)) {
+    } else if (index_key === null && array[i].hasOwnProperty(column_key)) {
       result[i] = array[i][column_key];
     } else if (array[i].hasOwnProperty(index_key)) {
       if (column_key === null) {


### PR DESCRIPTION
Just a little fix that makes `array_column` work without index key.