### PR TITLE
Fix for pack 'n*' returning 8 bit instead of 16

### DIFF
--- a/functions/misc/pack.js
+++ b/functions/misc/pack.js
@@ -151,6 +151,7 @@ function pack(format) {
       }
 
       for (i = 0; i < quantifier; i++) {
+        result += String.fromCharCode(arguments[argumentPointer] >> 8 & 0xFF);
         result += String.fromCharCode(arguments[argumentPointer] & 0xFF);
         argumentPointer++;
       }


### PR DESCRIPTION
I've encountered a small bug in *pack* function. In particular, when setting 'n*' format, it returns 8 bit instead of 16.
```
//js
fs.writeFile('test.js.dat', phpjs.pack('n*', 777), 'binary'); // Bytes written: 09

//php
file_put_contents('test.php.dat', pack('n*', 777)); // Bytes written: 03 09
```